### PR TITLE
Set reader point to position 0

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -54,6 +54,8 @@ class TestMd5Reader(TestCase):
             md5(contents).hexdigest()
         )
 
+        self.assertEqual(uploadedfile.tell(), 0)
+
     def test_wronghexdigest(self):
         uploadedfile = SimpleUploadedFile(
             'file',

--- a/api/utils.py
+++ b/api/utils.py
@@ -25,4 +25,5 @@ def md5reader(uploadedfile):
     for chunk in uploadedfile.chunks():
         hash_md5.update(chunk)
 
+    uploadedfile.seek(0)
     return hash_md5.hexdigest()


### PR DESCRIPTION
File was saved with 0 bytes after MD5 checksum. Reset read pointer.